### PR TITLE
Create cash receipt API extension

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "d3c4d2c7-5f0e-4e74-9a52-8a8b9f5e2c01",
+  "name": "Cash Receipt API",
+  "publisher": "YourCompany",
+  "version": "1.0.0.0",
+  "platform": "23.0.0.0",
+  "application": "23.0.0.0",
+  "idRanges": [
+    {
+      "from": 80100,
+      "to": 80149
+    }
+  ],
+  "runtime": "13.0",
+  "brief": "Custom API for creating and retrieving cash receipts.",
+  "description": "Exposes endpoints to create cash receipts (header with lines) and to retrieve posted and unposted cash receipts with their lines.",
+  "target": "Cloud",
+  "features": [
+    "NoImplicitWith"
+  ],
+  "dependencies": [],
+  "screenshots": [],
+  "contextSensitiveHelpUrl": "https://example.com/help/cash-receipt-api"
+}
+

--- a/src/80100_CRStagingHeader.al
+++ b/src/80100_CRStagingHeader.al
@@ -1,0 +1,70 @@
+table 80100 "CR Staging Header"
+{
+    Caption = 'Cash Receipt Staging Header';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Id"; Guid)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Journal Template Name"; Code[20])
+        {
+            Caption = 'Journal Template Name';
+            TableRelation = "Gen. Journal Template".Name;
+        }
+        field(3; "Journal Batch Name"; Code[20])
+        {
+            Caption = 'Journal Batch Name';
+            TableRelation = "Gen. Journal Batch".Name where("Journal Template Name" = field("Journal Template Name"));
+        }
+        field(4; "Document No."; Code[20])
+        {
+            Caption = 'Document No.';
+        }
+        field(5; "Posting Date"; Date)
+        {
+            Caption = 'Posting Date';
+        }
+        field(6; "External Document No."; Code[35])
+        {
+            Caption = 'External Document No.';
+        }
+        field(7; "Bal. Account Type"; Enum "Gen. Journal Account Type")
+        {
+            Caption = 'Bal. Account Type';
+        }
+        field(8; "Bal. Account No."; Code[20])
+        {
+            Caption = 'Bal. Account No.';
+            TableRelation = if ("Bal. Account Type" = const("G/L Account")) "G/L Account"."No."
+                            else if ("Bal. Account Type" = const(Customer)) Customer."No."
+                            else if ("Bal. Account Type" = const(Vendor)) Vendor."No."
+                            else if ("Bal. Account Type" = const("Bank Account")) "Bank Account"."No."
+                            else if ("Bal. Account Type" = const("Fixed Asset")) "Fixed Asset"."No."
+                            else if ("Bal. Account Type" = const("IC Partner")) "IC Partner".Code;
+        }
+        field(9; "Currency Code"; Code[10])
+        {
+            Caption = 'Currency Code';
+            TableRelation = Currency.Code;
+        }
+        field(10; "Description"; Text[100])
+        {
+            Caption = 'Description';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Id")
+        {
+            Clustered = true;
+        }
+        key(DocumentKey; "Journal Template Name", "Journal Batch Name", "Document No.")
+        {
+        }
+    }
+}
+

--- a/src/80101_CRStagingLine.al
+++ b/src/80101_CRStagingLine.al
@@ -1,0 +1,60 @@
+table 80101 "CR Staging Line"
+{
+    Caption = 'Cash Receipt Staging Line';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Id"; Guid)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Header Id"; Guid)
+        {
+            Caption = 'Header Id';
+            TableRelation = "CR Staging Header".Id;
+        }
+        field(3; "Line No."; Integer)
+        {
+            Caption = 'Line No.';
+        }
+        field(4; "Account Type"; Enum "Gen. Journal Account Type")
+        {
+            Caption = 'Account Type';
+        }
+        field(5; "Account No."; Code[20])
+        {
+            Caption = 'Account No.';
+            TableRelation = if ("Account Type" = const("G/L Account")) "G/L Account"."No."
+                            else if ("Account Type" = const(Customer)) Customer."No."
+                            else if ("Account Type" = const(Vendor)) Vendor."No."
+                            else if ("Account Type" = const("Bank Account")) "Bank Account"."No."
+                            else if ("Account Type" = const("Fixed Asset")) "Fixed Asset"."No."
+                            else if ("Account Type" = const("IC Partner")) "IC Partner".Code;
+        }
+        field(6; "Amount"; Decimal)
+        {
+            Caption = 'Amount';
+        }
+        field(7; "Description"; Text[100])
+        {
+            Caption = 'Description';
+        }
+        field(8; "Applies-to Doc. No."; Code[20])
+        {
+            Caption = 'Applies-to Doc. No.';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Id")
+        {
+            Clustered = true;
+        }
+        key(LineKey; "Header Id", "Line No.")
+        {
+        }
+    }
+}
+

--- a/src/80102_CRUnpostedHeaderView.al
+++ b/src/80102_CRUnpostedHeaderView.al
@@ -1,0 +1,38 @@
+table 80102 "CR Unposted Header View"
+{
+    Caption = 'Unposted Cash Receipt Header';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Journal Template Name"; Code[20])
+        {
+            Caption = 'Journal Template Name';
+        }
+        field(2; "Journal Batch Name"; Code[20])
+        {
+            Caption = 'Journal Batch Name';
+        }
+        field(3; "Document No."; Code[20])
+        {
+            Caption = 'Document No.';
+        }
+        field(4; "Posting Date"; Date)
+        {
+            Caption = 'Posting Date';
+        }
+        field(5; "External Document No."; Code[35])
+        {
+            Caption = 'External Document No.';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Journal Template Name", "Journal Batch Name", "Document No.")
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/src/80103_CRPostedHeaderView.al
+++ b/src/80103_CRPostedHeaderView.al
@@ -1,0 +1,35 @@
+table 80103 "CR Posted Header View"
+{
+    Caption = 'Posted Cash Receipt Header';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Document No."; Code[20])
+        {
+            Caption = 'Document No.';
+        }
+        field(2; "Posting Date"; Date)
+        {
+            Caption = 'Posting Date';
+        }
+        field(3; "Customer No."; Code[20])
+        {
+            Caption = 'Customer No.';
+            TableRelation = Customer."No.";
+        }
+        field(4; "Amount"; Decimal)
+        {
+            Caption = 'Amount';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Document No.")
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/src/80104_CRCombinedHeaderView.al
+++ b/src/80104_CRCombinedHeaderView.al
@@ -1,0 +1,58 @@
+table 80104 "CR Combined Header View"
+{
+    Caption = 'Cash Receipt Header (All)';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Id; Guid)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; Status; Enum "CR Receipt Status")
+        {
+            Caption = 'Status';
+        }
+        field(3; "Journal Template Name"; Code[20])
+        {
+            Caption = 'Journal Template Name';
+        }
+        field(4; "Journal Batch Name"; Code[20])
+        {
+            Caption = 'Journal Batch Name';
+        }
+        field(5; "Document No."; Code[20])
+        {
+            Caption = 'Document No.';
+        }
+        field(6; "Posting Date"; Date)
+        {
+            Caption = 'Posting Date';
+        }
+        field(7; "External Document No."; Code[35])
+        {
+            Caption = 'External Document No.';
+        }
+        field(8; "Customer No."; Code[20])
+        {
+            Caption = 'Customer No.';
+            TableRelation = Customer."No.";
+        }
+        field(9; Amount; Decimal)
+        {
+            Caption = 'Amount';
+        }
+    }
+
+    keys
+    {
+        key(PK; Id)
+        {
+            Clustered = true;
+        }
+        key(DocKey; Status, "Journal Template Name", "Journal Batch Name", "Document No.")
+        {
+        }
+    }
+}
+

--- a/src/80105_CRCombinedLineView.al
+++ b/src/80105_CRCombinedLineView.al
@@ -1,0 +1,87 @@
+table 80105 "CR Combined Line View"
+{
+    Caption = 'Cash Receipt Line (All)';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Id; Guid)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Header Id"; Guid)
+        {
+            Caption = 'Header Id';
+            TableRelation = "CR Combined Header View".Id;
+        }
+        field(3; Status; Enum "CR Receipt Status")
+        {
+            Caption = 'Status';
+        }
+        field(4; "Document No."; Code[20])
+        {
+            Caption = 'Document No.';
+        }
+        field(5; "Line No."; Integer)
+        {
+            Caption = 'Line No.';
+        }
+        field(6; "Posting Date"; Date)
+        {
+            Caption = 'Posting Date';
+        }
+        field(7; "Account Type"; Enum "Gen. Journal Account Type")
+        {
+            Caption = 'Account Type';
+        }
+        field(8; "Account No."; Code[20])
+        {
+            Caption = 'Account No.';
+        }
+        field(9; "Bal. Account Type"; Enum "Gen. Journal Account Type")
+        {
+            Caption = 'Bal. Account Type';
+        }
+        field(10; "Bal. Account No."; Code[20])
+        {
+            Caption = 'Bal. Account No.';
+        }
+        field(11; Amount; Decimal)
+        {
+            Caption = 'Amount';
+        }
+        field(12; "Currency Code"; Code[10])
+        {
+            Caption = 'Currency Code';
+        }
+        field(13; Description; Text[100])
+        {
+            Caption = 'Description';
+        }
+        field(14; "Applies-to Doc. No."; Code[20])
+        {
+            Caption = 'Applies-to Doc. No.';
+        }
+        field(15; "Customer No."; Code[20])
+        {
+            Caption = 'Customer No.';
+            TableRelation = Customer."No.";
+        }
+        field(16; "Entry No."; Integer)
+        {
+            Caption = 'Entry No.';
+        }
+    }
+
+    keys
+    {
+        key(PK; Id)
+        {
+            Clustered = true;
+        }
+        key(HeaderKey; "Header Id", "Line No.")
+        {
+        }
+    }
+}
+

--- a/src/80106_Enum_CRReceiptStatus.al
+++ b/src/80106_Enum_CRReceiptStatus.al
@@ -1,0 +1,15 @@
+enum 80106 "CR Receipt Status"
+{
+    Extensible = false;
+    AssignmentCompatibility = true;
+
+    value(0; Unposted)
+    {
+        Caption = 'Unposted';
+    }
+    value(1; Posted)
+    {
+        Caption = 'Posted';
+    }
+}
+

--- a/src/80110_api_CRCreateHeader.al
+++ b/src/80110_api_CRCreateHeader.al
@@ -1,0 +1,100 @@
+page 80110 "API CR Create Header"
+{
+    PageType = API;
+    Caption = 'Cash Receipt';
+    APIPublisher = 'yourcompany';
+    APIGroup = 'cashManagement';
+    APIVersion = 'v1.0';
+    EntityName = 'cashReceipt';
+    EntitySetName = 'cashReceipts';
+    SourceTable = "CR Staging Header";
+    DelayedInsert = true;
+    ODataKeyFields = Id;
+    Extensible = false;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(id; Rec.Id)
+                {
+                    Caption = 'Id';
+                    Editable = false;
+                }
+                field(journalTemplateName; Rec."Journal Template Name")
+                {
+                    Caption = 'Journal Template Name';
+                }
+                field(journalBatchName; Rec."Journal Batch Name")
+                {
+                    Caption = 'Journal Batch Name';
+                }
+                field(documentNo; Rec."Document No.")
+                {
+                    Caption = 'Document No.';
+                }
+                field(postingDate; Rec."Posting Date")
+                {
+                    Caption = 'Posting Date';
+                }
+                field(externalDocumentNo; Rec."External Document No.")
+                {
+                    Caption = 'External Document No.';
+                }
+                field(balAccountType; Rec."Bal. Account Type")
+                {
+                    Caption = 'Bal. Account Type';
+                }
+                field(balAccountNo; Rec."Bal. Account No.")
+                {
+                    Caption = 'Bal. Account No.';
+                }
+                field(currencyCode; Rec."Currency Code")
+                {
+                    Caption = 'Currency Code';
+                }
+                field(description; Rec.Description)
+                {
+                    Caption = 'Description';
+                }
+            }
+            part(lines; "API CR Create Lines")
+            {
+                EntityName = 'line';
+                EntitySetName = 'lines';
+                SubPageLink = "Header Id" = field(Id);
+                Caption = 'Lines';
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(CreateJournal)
+            {
+                Caption = 'Create Journal Lines';
+                ApplicationArea = All;
+                trigger OnAction()
+                var
+                    Creator: Codeunit "CR Create Endpoint";
+                    Header: Record "CR Staging Header";
+                begin
+                    Header := Rec;
+                    Creator.CreateCashReceipt(Header);
+                end;
+            }
+        }
+    }
+
+    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
+    begin
+        if Rec.Id = Guid::EmptyGuid() then
+            Rec.Id := CreateGuid();
+        exit(true);
+    end;
+}
+

--- a/src/80111_api_CRCreateLines.al
+++ b/src/80111_api_CRCreateLines.al
@@ -1,0 +1,69 @@
+page 80111 "API CR Create Lines"
+{
+    PageType = API;
+    Caption = 'Cash Receipt Line';
+    APIPublisher = 'yourcompany';
+    APIGroup = 'cashManagement';
+    APIVersion = 'v1.0';
+    EntityName = 'cashReceiptLine';
+    EntitySetName = 'cashReceiptLines';
+    SourceTable = "CR Staging Line";
+    DelayedInsert = true;
+    ODataKeyFields = Id;
+    Extensible = false;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(id; Rec.Id)
+                {
+                    Caption = 'Id';
+                    Editable = false;
+                }
+                field(headerId; Rec."Header Id")
+                {
+                    Caption = 'Header Id';
+                }
+                field(lineNo; Rec."Line No.")
+                {
+                    Caption = 'Line No.';
+                }
+                field(accountType; Rec."Account Type")
+                {
+                    Caption = 'Account Type';
+                }
+                field(accountNo; Rec."Account No.")
+                {
+                    Caption = 'Account No.';
+                }
+                field(amount; Rec.Amount)
+                {
+                    Caption = 'Amount';
+                }
+                field(description; Rec.Description)
+                {
+                    Caption = 'Description';
+                }
+                field(appliesToDocNo; Rec."Applies-to Doc. No.")
+                {
+                    Caption = 'Applies-to Doc. No.';
+                }
+            }
+        }
+    }
+
+    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
+    var
+        StagingLine: Record "CR Staging Line";
+    begin
+        if Rec.Id = Guid::EmptyGuid() then
+            Rec.Id := CreateGuid();
+        if Rec."Line No." = 0 then
+            Rec."Line No." := 10000;
+        exit(true);
+    end;
+}
+

--- a/src/80112_API_CRUnpostedHeader.al
+++ b/src/80112_API_CRUnpostedHeader.al
@@ -1,0 +1,60 @@
+page 80112 "API CR Unposted Header"
+{
+    PageType = API;
+    Caption = 'Unposted Cash Receipt';
+    APIPublisher = 'yourcompany';
+    APIGroup = 'cashManagement';
+    APIVersion = 'v1.0';
+    EntityName = 'unpostedCashReceipt';
+    EntitySetName = 'unpostedCashReceipts';
+    SourceTable = "CR Unposted Header View";
+    ODataKeyFields = "Journal Template Name", "Journal Batch Name", "Document No.";
+    DelayedInsert = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(journalTemplateName; Rec."Journal Template Name")
+                {
+                    Caption = 'Journal Template Name';
+                }
+                field(journalBatchName; Rec."Journal Batch Name")
+                {
+                    Caption = 'Journal Batch Name';
+                }
+                field(documentNo; Rec."Document No.")
+                {
+                    Caption = 'Document No.';
+                }
+                field(postingDate; Rec."Posting Date")
+                {
+                    Caption = 'Posting Date';
+                }
+                field(externalDocumentNo; Rec."External Document No.")
+                {
+                    Caption = 'External Document No.';
+                }
+            }
+            part(lines; "API CR Unposted Lines")
+            {
+                EntityName = 'line';
+                EntitySetName = 'lines';
+                SubPageLink = "Journal Template Name" = field("Journal Template Name"),
+                              "Journal Batch Name" = field("Journal Batch Name"),
+                              "Document No." = field("Document No.");
+                Caption = 'Lines';
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    var
+        Builder: Codeunit "CR View Builder";
+    begin
+        Builder.RebuildUnpostedHeaders();
+    end;
+}
+

--- a/src/80113_API_CRUnpostedLine.al
+++ b/src/80113_API_CRUnpostedLine.al
@@ -1,0 +1,83 @@
+page 80113 "API CR Unposted Lines"
+{
+    PageType = API;
+    Caption = 'Unposted Cash Receipt Line';
+    APIPublisher = 'yourcompany';
+    APIGroup = 'cashManagement';
+    APIVersion = 'v1.0';
+    EntityName = 'unpostedCashReceiptLine';
+    EntitySetName = 'unpostedCashReceiptLines';
+    SourceTable = "Gen. Journal Line";
+    ODataKeyFields = "Journal Template Name", "Journal Batch Name", "Document No.", "Line No.";
+    DelayedInsert = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(journalTemplateName; Rec."Journal Template Name")
+                {
+                    Caption = 'Journal Template Name';
+                }
+                field(journalBatchName; Rec."Journal Batch Name")
+                {
+                    Caption = 'Journal Batch Name';
+                }
+                field(documentNo; Rec."Document No.")
+                {
+                    Caption = 'Document No.';
+                }
+                field(lineNo; Rec."Line No.")
+                {
+                    Caption = 'Line No.';
+                }
+                field(postingDate; Rec."Posting Date")
+                {
+                    Caption = 'Posting Date';
+                }
+                field(accountType; Rec."Account Type")
+                {
+                    Caption = 'Account Type';
+                }
+                field(accountNo; Rec."Account No.")
+                {
+                    Caption = 'Account No.';
+                }
+                field(balAccountType; Rec."Bal. Account Type")
+                {
+                    Caption = 'Bal. Account Type';
+                }
+                field(balAccountNo; Rec."Bal. Account No.")
+                {
+                    Caption = 'Bal. Account No.';
+                }
+                field(amount; Rec.Amount)
+                {
+                    Caption = 'Amount';
+                }
+                field(currencyCode; Rec."Currency Code")
+                {
+                    Caption = 'Currency Code';
+                }
+                field(description; Rec.Description)
+                {
+                    Caption = 'Description';
+                }
+                field(appliesToDocNo; Rec."Applies-to Doc. No.")
+                {
+                    Caption = 'Applies-to Doc. No.';
+                }
+            }
+        }
+    }
+
+    trigger OnAfterGetRecord()
+    begin
+        Rec.SetRange("Journal Template Name", Rec."Journal Template Name");
+        Rec.SetRange("Journal Batch Name", Rec."Journal Batch Name");
+        Rec.SetRange("Document No.", Rec."Document No.");
+    end;
+}
+

--- a/src/80114_API_CRPostedHeader.al
+++ b/src/80114_API_CRPostedHeader.al
@@ -1,0 +1,54 @@
+page 80114 "API CR Posted Header"
+{
+    PageType = API;
+    Caption = 'Posted Cash Receipt';
+    APIPublisher = 'yourcompany';
+    APIGroup = 'cashManagement';
+    APIVersion = 'v1.0';
+    EntityName = 'postedCashReceipt';
+    EntitySetName = 'postedCashReceipts';
+    SourceTable = "CR Posted Header View";
+    ODataKeyFields = "Document No.";
+    DelayedInsert = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(documentNo; Rec."Document No.")
+                {
+                    Caption = 'Document No.';
+                }
+                field(postingDate; Rec."Posting Date")
+                {
+                    Caption = 'Posting Date';
+                }
+                field(customerNo; Rec."Customer No.")
+                {
+                    Caption = 'Customer No.';
+                }
+                field(amount; Rec.Amount)
+                {
+                    Caption = 'Amount';
+                }
+            }
+            part(lines; "API CR Posted Lines")
+            {
+                EntityName = 'line';
+                EntitySetName = 'lines';
+                SubPageLink = "Document No." = field("Document No.");
+                Caption = 'Lines';
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    var
+        Builder: Codeunit "CR View Builder";
+    begin
+        Builder.RebuildPostedHeaders();
+    end;
+}
+

--- a/src/80115_API_CRPostedLine.al
+++ b/src/80115_API_CRPostedLine.al
@@ -1,0 +1,61 @@
+page 80115 "API CR Posted Lines"
+{
+    PageType = API;
+    Caption = 'Posted Cash Receipt Line';
+    APIPublisher = 'yourcompany';
+    APIGroup = 'cashManagement';
+    APIVersion = 'v1.0';
+    EntityName = 'postedCashReceiptLine';
+    EntitySetName = 'postedCashReceiptLines';
+    SourceTable = "Cust. Ledger Entry";
+    ODataKeyFields = "Entry No.";
+    DelayedInsert = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(entryNo; Rec."Entry No.")
+                {
+                    Caption = 'Entry No.';
+                }
+                field(documentNo; Rec."Document No.")
+                {
+                    Caption = 'Document No.';
+                }
+                field(postingDate; Rec."Posting Date")
+                {
+                    Caption = 'Posting Date';
+                }
+                field(customerNo; Rec."Customer No.")
+                {
+                    Caption = 'Customer No.';
+                }
+                field(amount; Rec.Amount)
+                {
+                    Caption = 'Amount';
+                }
+                field(currencyCode; Rec."Currency Code")
+                {
+                    Caption = 'Currency Code';
+                }
+                field(description; Rec.Description)
+                {
+                    Caption = 'Description';
+                }
+                field(appliesToDocNo; Rec."Applies-to Doc. No.")
+                {
+                    Caption = 'Applies-to Doc. No.';
+                }
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    begin
+        Rec.SetRange("Document Type", Rec."Document Type"::Payment);
+    end;
+}
+

--- a/src/80116_API_CRCombinedHeader.al
+++ b/src/80116_API_CRCombinedHeader.al
@@ -1,0 +1,84 @@
+page 80116 "API CR Combined Header"
+{
+    PageType = API;
+    Caption = 'Cash Receipt (All)';
+    APIPublisher = 'yourcompany';
+    APIGroup = 'cashManagement';
+    APIVersion = 'v1.0';
+    EntityName = 'cashReceiptAll';
+    EntitySetName = 'cashReceiptsAll';
+    SourceTable = "CR Combined Header View";
+    ODataKeyFields = Id;
+    DelayedInsert = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(id; Rec.Id)
+                {
+                    Caption = 'Id';
+                }
+                field(status; Rec.Status)
+                {
+                    Caption = 'Status';
+                }
+                field(journalTemplateName; Rec."Journal Template Name")
+                {
+                    Caption = 'Journal Template Name';
+                }
+                field(journalBatchName; Rec."Journal Batch Name")
+                {
+                    Caption = 'Journal Batch Name';
+                }
+                field(documentNo; Rec."Document No.")
+                {
+                    Caption = 'Document No.';
+                }
+                field(postingDate; Rec."Posting Date")
+                {
+                    Caption = 'Posting Date';
+                }
+                field(externalDocumentNo; Rec."External Document No.")
+                {
+                    Caption = 'External Document No.';
+                }
+                field(customerNo; Rec."Customer No.")
+                {
+                    Caption = 'Customer No.';
+                }
+                field(amount; Rec.Amount)
+                {
+                    Caption = 'Amount';
+                }
+            }
+            part(lines; "API CR Combined Lines")
+            {
+                EntityName = 'line';
+                EntitySetName = 'lines';
+                SubPageLink = "Header Id" = field(Id);
+                Caption = 'Lines';
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    var
+        Builder: Codeunit "CR Combined Builder";
+    begin
+        ClearCombined();
+        Builder.Rebuild();
+    end;
+
+    local procedure ClearCombined()
+    var
+        H: Record "CR Combined Header View";
+        L: Record "CR Combined Line View";
+    begin
+        L.DeleteAll();
+        H.DeleteAll();
+    end;
+}
+

--- a/src/80117_API_CRCombinedLine.al
+++ b/src/80117_API_CRCombinedLine.al
@@ -1,0 +1,88 @@
+page 80117 "API CR Combined Lines"
+{
+    PageType = API;
+    Caption = 'Cash Receipt Line (All)';
+    APIPublisher = 'yourcompany';
+    APIGroup = 'cashManagement';
+    APIVersion = 'v1.0';
+    EntityName = 'cashReceiptAllLine';
+    EntitySetName = 'cashReceiptsAllLines';
+    SourceTable = "CR Combined Line View";
+    ODataKeyFields = Id;
+    DelayedInsert = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(id; Rec.Id)
+                {
+                    Caption = 'Id';
+                }
+                field(headerId; Rec."Header Id")
+                {
+                    Caption = 'Header Id';
+                }
+                field(status; Rec.Status)
+                {
+                    Caption = 'Status';
+                }
+                field(documentNo; Rec."Document No.")
+                {
+                    Caption = 'Document No.';
+                }
+                field(lineNo; Rec."Line No.")
+                {
+                    Caption = 'Line No.';
+                }
+                field(postingDate; Rec."Posting Date")
+                {
+                    Caption = 'Posting Date';
+                }
+                field(accountType; Rec."Account Type")
+                {
+                    Caption = 'Account Type';
+                }
+                field(accountNo; Rec."Account No.")
+                {
+                    Caption = 'Account No.';
+                }
+                field(balAccountType; Rec."Bal. Account Type")
+                {
+                    Caption = 'Bal. Account Type';
+                }
+                field(balAccountNo; Rec."Bal. Account No.")
+                {
+                    Caption = 'Bal. Account No.';
+                }
+                field(amount; Rec.Amount)
+                {
+                    Caption = 'Amount';
+                }
+                field(currencyCode; Rec."Currency Code")
+                {
+                    Caption = 'Currency Code';
+                }
+                field(description; Rec.Description)
+                {
+                    Caption = 'Description';
+                }
+                field(appliesToDocNo; Rec."Applies-to Doc. No.")
+                {
+                    Caption = 'Applies-to Doc. No.';
+                }
+                field(customerNo; Rec."Customer No.")
+                {
+                    Caption = 'Customer No.';
+                }
+                field(entryNo; Rec."Entry No.")
+                {
+                    Caption = 'Entry No.';
+                }
+            }
+        }
+    }
+}
+

--- a/src/80140_CRViewBuilder.al
+++ b/src/80140_CRViewBuilder.al
@@ -1,0 +1,68 @@
+codeunit 80140 "CR View Builder"
+{
+    SingleInstance = false;
+
+    procedure RebuildUnpostedHeaders()
+    var
+        GenJnlLine: Record "Gen. Journal Line";
+        HeaderView: Record "CR Unposted Header View";
+        GenJnlTemplate: Record "Gen. Journal Template";
+        LastTemplateName: Code[20];
+    begin
+        HeaderView.DeleteAll();
+
+        GenJnlTemplate.Reset();
+        GenJnlTemplate.SetRange(Type, GenJnlTemplate.Type::"Cash Receipts");
+        if GenJnlTemplate.FindSet() then
+            repeat
+                GenJnlLine.Reset();
+                GenJnlLine.SetRange("Journal Template Name", GenJnlTemplate.Name);
+                if GenJnlLine.FindSet() then
+                    repeat
+                        if not HeaderView.Get(GenJnlLine."Journal Template Name", GenJnlLine."Journal Batch Name", GenJnlLine."Document No.") then begin
+                            HeaderView.Init();
+                            HeaderView."Journal Template Name" := GenJnlLine."Journal Template Name";
+                            HeaderView."Journal Batch Name" := GenJnlLine."Journal Batch Name";
+                            HeaderView."Document No." := GenJnlLine."Document No.";
+                            HeaderView."Posting Date" := GenJnlLine."Posting Date";
+                            HeaderView."External Document No." := GenJnlLine."External Document No.";
+                            HeaderView.Insert();
+                        end;
+                    until GenJnlLine.Next() = 0;
+            until GenJnlTemplate.Next() = 0;
+    end;
+
+    procedure RebuildPostedHeaders()
+    var
+        CustLedgEntry: Record "Cust. Ledger Entry";
+        CustLedgEntry2: Record "Cust. Ledger Entry";
+        HeaderView: Record "CR Posted Header View";
+        AmountSum: Decimal;
+    begin
+        HeaderView.DeleteAll();
+
+        CustLedgEntry.Reset();
+        CustLedgEntry.SetRange("Document Type", CustLedgEntry."Document Type"::Payment);
+        if CustLedgEntry.FindSet() then
+            repeat
+                if not HeaderView.Get(CustLedgEntry."Document No.") then begin
+                    AmountSum := 0;
+                    CustLedgEntry2.Reset();
+                    CustLedgEntry2.SetRange("Document No.", CustLedgEntry."Document No.");
+                    CustLedgEntry2.SetRange("Document Type", CustLedgEntry2."Document Type"::Payment);
+                    if CustLedgEntry2.FindSet() then
+                        repeat
+                            AmountSum += CustLedgEntry2.Amount;
+                        until CustLedgEntry2.Next() = 0;
+
+                    HeaderView.Init();
+                    HeaderView."Document No." := CustLedgEntry."Document No.";
+                    HeaderView."Posting Date" := CustLedgEntry."Posting Date";
+                    HeaderView."Customer No." := CustLedgEntry."Customer No.";
+                    HeaderView.Amount := AmountSum;
+                    HeaderView.Insert();
+                end;
+            until CustLedgEntry.Next() = 0;
+    end;
+}
+

--- a/src/80141_CRJournalMgt.al
+++ b/src/80141_CRJournalMgt.al
@@ -1,0 +1,69 @@
+codeunit 80141 "CR Journal Mgt"
+{
+    Permissions =
+        tabledata "Gen. Journal Line" = RIMD,
+        tabledata "Gen. Journal Batch" = R,
+        tabledata "Gen. Journal Template" = R,
+        tabledata Currency = R,
+        tabledata Customer = R,
+        tabledata Vendor = R,
+        tabledata "Bank Account" = R,
+        tabledata "G/L Account" = R;
+
+    procedure EnsureBatchExists(JournalTemplateName: Code[20]; JournalBatchName: Code[20])
+    var
+        GenJnlBatch: Record "Gen. Journal Batch";
+    begin
+        GenJnlBatch.Reset();
+        GenJnlBatch.SetRange("Journal Template Name", JournalTemplateName);
+        GenJnlBatch.SetRange(Name, JournalBatchName);
+        if not GenJnlBatch.FindFirst() then
+            Error('Journal Batch %1 for Template %2 not found.', JournalBatchName, JournalTemplateName);
+    end;
+
+    procedure CreateJournalLineFromStagingLine(StagingLine: Record "CR Staging Line"; Header: Record "CR Staging Header")
+    var
+        GenJnlLine: Record "Gen. Journal Line";
+        MaxLineNo: Integer;
+    begin
+        EnsureBatchExists(Header."Journal Template Name", Header."Journal Batch Name");
+
+        GenJnlLine.Reset();
+        GenJnlLine.SetRange("Journal Template Name", Header."Journal Template Name");
+        GenJnlLine.SetRange("Journal Batch Name", Header."Journal Batch Name");
+        GenJnlLine.SetRange("Document No.", Header."Document No.");
+        if GenJnlLine.FindLast() then
+            MaxLineNo := GenJnlLine."Line No."
+        else
+            MaxLineNo := 0;
+
+        GenJnlLine.Init();
+        GenJnlLine.Validate("Journal Template Name", Header."Journal Template Name");
+        GenJnlLine.Validate("Journal Batch Name", Header."Journal Batch Name");
+        GenJnlLine."Line No." := MaxLineNo + 10000;
+        GenJnlLine.Validate("Document No.", Header."Document No.");
+        if Header."Posting Date" <> 0D then
+            GenJnlLine.Validate("Posting Date", Header."Posting Date");
+        if Header."External Document No." <> '' then
+            GenJnlLine.Validate("External Document No.", Header."External Document No.");
+
+        GenJnlLine.Validate("Account Type", StagingLine."Account Type");
+        GenJnlLine.Validate("Account No.", StagingLine."Account No.");
+        if Header."Bal. Account Type" <> GenJnlLine."Bal. Account Type" then
+            GenJnlLine.Validate("Bal. Account Type", Header."Bal. Account Type");
+        if Header."Bal. Account No." <> '' then
+            GenJnlLine.Validate("Bal. Account No.", Header."Bal. Account No.");
+
+        if Header."Currency Code" <> '' then
+            GenJnlLine.Validate("Currency Code", Header."Currency Code");
+
+        if StagingLine.Description <> '' then
+            GenJnlLine.Validate(Description, StagingLine.Description);
+        if StagingLine."Applies-to Doc. No." <> '' then
+            GenJnlLine.Validate("Applies-to Doc. No.", StagingLine."Applies-to Doc. No.");
+
+        GenJnlLine.Validate(Amount, StagingLine.Amount);
+        GenJnlLine.Insert(true);
+    end;
+}
+

--- a/src/80142_CRCreateEndpoint.al
+++ b/src/80142_CRCreateEndpoint.al
@@ -1,0 +1,16 @@
+codeunit 80142 "CR Create Endpoint"
+{
+    procedure CreateCashReceipt(var Header: Record "CR Staging Header")
+    var
+        StagingLine: Record "CR Staging Line";
+        JournalMgt: Codeunit "CR Journal Mgt";
+    begin
+        StagingLine.Reset();
+        StagingLine.SetRange("Header Id", Header.Id);
+        if StagingLine.FindSet() then
+            repeat
+                JournalMgt.CreateJournalLineFromStagingLine(StagingLine, Header);
+            until StagingLine.Next() = 0;
+    end;
+}
+

--- a/src/80143_CRCombinedBuilder.al
+++ b/src/80143_CRCombinedBuilder.al
@@ -1,0 +1,126 @@
+codeunit 80143 "CR Combined Builder"
+{
+    procedure Rebuild()
+    begin
+        BuildUnposted();
+        BuildPosted();
+    end;
+
+    local procedure BuildUnposted()
+    var
+        Header: Record "CR Combined Header View";
+        Line: Record "CR Combined Line View";
+        GenJnlLine: Record "Gen. Journal Line";
+        AmountSum: Decimal;
+        HeaderId: Guid;
+    begin
+        GenJnlLine.Reset();
+        if GenJnlLine.FindSet() then
+            repeat
+                if GenJnlLine."Document No." = '' then
+                    continue;
+
+                if not HasHeader(Header, GenJnlLine."Journal Template Name", GenJnlLine."Journal Batch Name", GenJnlLine."Document No.", Enum::"CR Receipt Status".Unposted, HeaderId) then begin
+                    AmountSum := SumUnposted(GenJnlLine);
+                    Header.Init();
+                    Header.Id := CreateGuid();
+                    Header.Status := Header.Status::Unposted;
+                    Header."Journal Template Name" := GenJnlLine."Journal Template Name";
+                    Header."Journal Batch Name" := GenJnlLine."Journal Batch Name";
+                    Header."Document No." := GenJnlLine."Document No.";
+                    Header."Posting Date" := GenJnlLine."Posting Date";
+                    Header."External Document No." := GenJnlLine."External Document No.";
+                    Header.Amount := AmountSum;
+                    Header.Insert();
+                    HeaderId := Header.Id;
+                end;
+
+                Line.Init();
+                Line.Id := CreateGuid();
+                Line."Header Id" := HeaderId;
+                Line.Status := Line.Status::Unposted;
+                Line."Document No." := GenJnlLine."Document No.";
+                Line."Line No." := GenJnlLine."Line No.";
+                Line."Posting Date" := GenJnlLine."Posting Date";
+                Line."Account Type" := GenJnlLine."Account Type";
+                Line."Account No." := GenJnlLine."Account No.";
+                Line."Bal. Account Type" := GenJnlLine."Bal. Account Type";
+                Line."Bal. Account No." := GenJnlLine."Bal. Account No.";
+                Line.Amount := GenJnlLine.Amount;
+                Line."Currency Code" := GenJnlLine."Currency Code";
+                Line.Description := GenJnlLine.Description;
+                Line."Applies-to Doc. No." := GenJnlLine."Applies-to Doc. No.";
+                Line.Insert();
+            until GenJnlLine.Next() = 0;
+    end;
+
+    local procedure BuildPosted()
+    var
+        Header: Record "CR Combined Header View";
+        Line: Record "CR Combined Line View";
+        CustLedgEntry: Record "Cust. Ledger Entry";
+        CustLedgEntryLine: Record "Cust. Ledger Entry";
+        AmountSum: Decimal;
+        HeaderId: Guid;
+    begin
+        CustLedgEntry.Reset();
+        CustLedgEntry.SetRange("Document Type", CustLedgEntry."Document Type"::Payment);
+        if CustLedgEntry.FindSet() then
+            repeat
+                if not HasHeader(Header, '', '', CustLedgEntry."Document No.", Enum::"CR Receipt Status".Posted, HeaderId) then begin
+                    AmountSum := 0;
+                    CustLedgEntryLine.Reset();
+                    CustLedgEntryLine.SetRange("Document No.", CustLedgEntry."Document No.");
+                    CustLedgEntryLine.SetRange("Document Type", CustLedgEntryLine."Document Type"::Payment);
+                    if CustLedgEntryLine.FindSet() then
+                        repeat
+                            AmountSum += CustLedgEntryLine.Amount;
+                        until CustLedgEntryLine.Next() = 0;
+
+                    Header.Init();
+                    Header.Id := CreateGuid();
+                    Header.Status := Header.Status::Posted;
+                    Header."Document No." := CustLedgEntry."Document No.";
+                    Header."Posting Date" := CustLedgEntry."Posting Date";
+                    Header."Customer No." := CustLedgEntry."Customer No.";
+                    Header.Amount := AmountSum;
+                    Header.Insert();
+                    HeaderId := Header.Id;
+                end;
+
+                Line.Init();
+                Line.Id := CreateGuid();
+                Line."Header Id" := HeaderId;
+                Line.Status := Line.Status::Posted;
+                Line."Document No." := CustLedgEntry."Document No.";
+                Line."Line No." := CustLedgEntry."Entry No.";
+                Line."Posting Date" := CustLedgEntry."Posting Date";
+                Line."Account Type" := Line."Account Type"::Customer;
+                Line."Account No." := CustLedgEntry."Customer No.";
+                Line.Amount := CustLedgEntry.Amount;
+                Line."Currency Code" := CustLedgEntry."Currency Code";
+                Line.Description := CustLedgEntry.Description;
+                Line."Applies-to Doc. No." := CustLedgEntry."Applies-to Doc. No.";
+                Line."Customer No." := CustLedgEntry."Customer No.";
+                Line."Entry No." := CustLedgEntry."Entry No.";
+                Line.Insert();
+            until CustLedgEntry.Next() = 0;
+    end;
+
+    local procedure HasHeader(var Header: Record "CR Combined Header View"; Template: Code[20]; Batch: Code[20]; DocumentNo: Code[20]; Status: Enum "CR Receipt Status"; var HeaderId: Guid): Boolean
+    begin
+        Header.Reset();
+        Header.SetRange(Status, Status);
+        Header.SetRange("Journal Template Name", Template);
+        Header.SetRange("Journal Batch Name", Batch);
+        Header.SetRange("Document No.", DocumentNo);
+        if Header.FindFirst() then begin
+            HeaderId := Header.Id;
+            exit(true);
+        end else begin
+            HeaderId := Guid::EmptyGuid();
+            exit(false);
+        end;
+    end;
+}
+

--- a/src/80150_Perm_CashReceiptAPI.al
+++ b/src/80150_Perm_CashReceiptAPI.al
@@ -1,0 +1,29 @@
+permissionset 80150 "CR API"
+{
+    Assignable = true;
+    Caption = 'Cash Receipt API Access';
+
+    Permissions =
+        tabledata "CR Staging Header" = RIMD,
+        tabledata "CR Staging Line" = RIMD,
+        tabledata "CR Unposted Header View" = RIMD,
+        tabledata "CR Posted Header View" = RIMD,
+        tabledata "Gen. Journal Line" = RIMD,
+        tabledata "Gen. Journal Batch" = R,
+        tabledata "Gen. Journal Template" = R,
+        tabledata "Cust. Ledger Entry" = R,
+        tabledata Customer = R,
+        tabledata Vendor = R,
+        tabledata "G/L Account" = R,
+        tabledata "Bank Account" = R,
+        page "API CR Create Header" = X,
+        page "API CR Create Lines" = X,
+        page "API CR Unposted Header" = X,
+        page "API CR Unposted Lines" = X,
+        page "API CR Posted Header" = X,
+        page "API CR Posted Lines" = X,
+        codeunit "CR View Builder" = X,
+        codeunit "CR Journal Mgt" = X,
+        codeunit "CR Create Endpoint" = X;
+}
+

--- a/src/80150_Perm_CashReceiptAPI.al
+++ b/src/80150_Perm_CashReceiptAPI.al
@@ -22,8 +22,11 @@ permissionset 80150 "CR API"
         page "API CR Unposted Lines" = X,
         page "API CR Posted Header" = X,
         page "API CR Posted Lines" = X,
+        page "API CR Combined Header" = X,
+        page "API CR Combined Lines" = X,
         codeunit "CR View Builder" = X,
         codeunit "CR Journal Mgt" = X,
-        codeunit "CR Create Endpoint" = X;
+        codeunit "CR Create Endpoint" = X,
+        codeunit "CR Combined Builder" = X;
 }
 


### PR DESCRIPTION
Introduces a new AL extension to expose custom API pages for creating and retrieving Business Central Cash Receipts with nested lines.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1fefc2c-aa33-4f12-9c91-f413faadfd42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1fefc2c-aa33-4f12-9c91-f413faadfd42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

